### PR TITLE
Enhance robustness of PPM parsing

### DIFF
--- a/Src/stm32f1xx_it.c
+++ b/Src/stm32f1xx_it.c
@@ -158,6 +158,9 @@ void PendSV_Handler(void) {
 /**
 * @brief This function handles System tick timer.
 */
+#ifdef CONTROL_PPM
+void PPM_SysTick_Callback(void);
+#endif
 void SysTick_Handler(void) {
   /* USER CODE BEGIN SysTick_IRQn 0 */
 
@@ -165,7 +168,9 @@ void SysTick_Handler(void) {
   HAL_IncTick();
   HAL_SYSTICK_IRQHandler();
   /* USER CODE BEGIN SysTick_IRQn 1 */
-
+#ifdef CONTROL_PPM
+  PPM_SysTick_Callback();
+#endif
   /* USER CODE END SysTick_IRQn 1 */
 }
 


### PR DESCRIPTION
Add additional checks to ensure only valid PPM pulse trains are accepted.
Add auto-idle feature to ensure vehicle stops if PPM signal is lost.

The above enhancements make control by signals from PPM sources like wireless receivers much more reliable to a point where no further external components for signal and/or power supply filtering are required anymore. 

Co-authored-by: Tobias Mädel <t.maedel@alfeld.de>